### PR TITLE
Fixed roles assignement for lead machine

### DIFF
--- a/AWACPM.psm1
+++ b/AWACPM.psm1
@@ -177,7 +177,7 @@ function Start-OfficeWebAppsPatch
         New-OfficeWebAppsFarm @parms
         Write-host -ForegroundColor Green 'Completed creating farm.'
         Write-Host -ForegroundColor Green 'Setting Office Web Apps Machine Roles.'
-        Get-MachineXml
+        $machine = Get-MachineXml
         Set-OfficeWebAppsMachine -Roles $machine.Roles
         Write-Host -ForegroundColor Green 'Completed setting machine roles.'
     }


### PR DESCRIPTION
Fix for issue #3  
Storing Get-MachineXml output in the $machine variable lets the following Set-OfficeWebAppsMachine cmdlet to apply the proper role to lead machine